### PR TITLE
Make sure the docker reference is valid

### DIFF
--- a/lib/minitest/docker/reporter.rb
+++ b/lib/minitest/docker/reporter.rb
@@ -21,7 +21,8 @@ module Minitest
         ::Docker::Container.all.each do |container|
           container_name = container.info['Names'].min_by(&:length)
 
-          test_name = result.name.gsub(/[^a-zA-Z0-9_.-]/, '_')
+          test_name = result.name.gsub(/[^a-zA-Z0-9_.]/, '_')
+          test_name.gsub!(/_+/, '_')
 
           tag = test_name + container_name
           container.commit.tag(repo: tag, force: true)


### PR DESCRIPTION
When a test is something like `it 'works when using --dry-run' do ... end` the `test_name` is something like `test_0001_works_when_using_--dry-run`.

Without making both of these changes I saw errors like this:

```
/Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.29.0/lib/docker/connection.rb:50:in `rescue in request': invalid reference format (Docker::Error::ServerError)
	from /Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.29.0/lib/docker/connection.rb:38:in `request'
	from /Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.29.0/lib/docker/connection.rb:65:in `block (2 levels) in <class:Connection>'
	from /Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.29.0/lib/docker/image.rb:43:in `tag'
	from /Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-docker-0.0.2/lib/minitest/docker/reporter.rb:31:in `block in record'
	from /Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-docker-0.0.2/lib/minitest/docker/reporter.rb:21:in `each'
	from /Users/rsandler/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/minitest-docker-0.0.2/lib/minitest/docker/reporter.rb:21:in `record'
```

@steved @neroleung